### PR TITLE
Use System OS name instead of library name in ident

### DIFF
--- a/Utils/Constants.pike
+++ b/Utils/Constants.pike
@@ -12,7 +12,7 @@ class Constants {
           "d": ([
             "token": token,
             "properties": ([
-                "$os": "Fisher",
+                "$os": System.uname()["sysname"],
                 "$browser": "Fisher",
                 "$device": "Fisher",
                 "$referrer": "",


### PR DESCRIPTION
Fix error that shows "$os" as library name instead of the operating system name.